### PR TITLE
Correcting RPM-based installation wrt to GPG key import/validation for GitLab EE

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,10 @@
 ---
 # https://packages.gitlab.com/gitlab/
 gitlab_mirror: https://packages.gitlab.com
-gitlab_ver: 13.5.1
+gitlab_ver: 13.6.1
 gitlab_patch: 0
 
 gitlab_dist: ce
-
-gitlab_key_urls:
-  - https://packages.gitlab.com/gpg.key
 
 gitlab_os_dep_pkgs:
   - openssh-server

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,12 @@ gitlab_patch: 0
 
 gitlab_dist: ce
 
+gitlab_key_urls:
+  - https://packages.gitlab.com/gpg.key
+  # Manual RPM-based installation GPG Keys (ref: https://packages.gitlab.com/gitlab/gitlab-ee/install#manual-rpm)
+  - https://packages.gitlab.com/gitlab/gitlab-ee/gpgkey
+  - https://packages.gitlab.com/gitlab/gitlab-ee/gpgkey/gitlab-gitlab-ee-3D645A26AB9FBD22.pub.gpg
+
 gitlab_os_dep_pkgs:
   - openssh-server
   - postfix

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,6 @@
 ---
 # vars file for gitlab
 gitlab_local_pkg: '{{ gitlab_pkg_dir }}/{{ gitlab_pkg }}'
+
+# Manual RPM-based installation GPG Keys (ref: https://packages.gitlab.com/gitlab/gitlab-ee/install#manual-rpm)
+gitlab_key_urls: '{{ (gitlab_dist == "ee" and ansible_pkg_mgr in ["dnf", "yum"]) | ternary(["https://packages.gitlab.com/gitlab/gitlab-ee/gpgkey", "https://packages.gitlab.com/gitlab/gitlab-ee/gpgkey/gitlab-gitlab-ee-3D645A26AB9FBD22.pub.gpg"], ["https://packages.gitlab.com/gpg.key"]) }}'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,3 @@
 ---
 # vars file for gitlab
 gitlab_local_pkg: '{{ gitlab_pkg_dir }}/{{ gitlab_pkg }}'
-
-# Manual RPM-based installation GPG Keys (ref: https://packages.gitlab.com/gitlab/gitlab-ee/install#manual-rpm)
-gitlab_key_urls: '{{ (gitlab_dist == "ee" and ansible_pkg_mgr in ["dnf", "yum"]) | ternary(["https://packages.gitlab.com/gitlab/gitlab-ee/gpgkey", "https://packages.gitlab.com/gitlab/gitlab-ee/gpgkey/gitlab-gitlab-ee-3D645A26AB9FBD22.pub.gpg"], ["https://packages.gitlab.com/gpg.key"]) }}'


### PR DESCRIPTION
… for RPM-based installation platforms, bumping default gitlab installation version to v13.6.1